### PR TITLE
Feature/TRD-3509: Update South Florida table to add stick header and added detail view

### DIFF
--- a/south-florida/south-florida-transactions-table.css
+++ b/south-florida/south-florida-transactions-table.css
@@ -1,0 +1,94 @@
+@font-face {
+  font-family: "Proxima Nova";
+  src: url("https://static.therealdeal.com/fonts/ProximaNova/ProximaNova-Extrabld.woff2")
+      format("woff2"),
+    url("https://static.therealdeal.com/fonts/ProximaNova/ProximaNova-Extrabld.woff")
+      format("woff"),
+    url("https://static.therealdeal.com/fonts/ProximaNova/ProximaNova-Extrabld.ttf")
+      format("truetype");
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Proxima Nova";
+  src: url("https://static.therealdeal.com/fonts/ProximaNova/ProximaNova-Semibold.woff2")
+      format("woff2"),
+    url("https://static.therealdeal.com/fonts/ProximaNova/ProximaNova-Semibold.woff")
+      format("woff"),
+    url("https://static.therealdeal.com/fonts/ProximaNova/ProximaNova-Semibold.ttf")
+      format("truetype");
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Proxima Nova";
+  src: url("https://static.therealdeal.com/fonts/ProximaNova/ProximaNova-Regular.woff2")
+      format("woff2"),
+    url("https://static.therealdeal.com/fonts/ProximaNova/ProximaNova-Regular.woff")
+      format("woff"),
+    url("https://static.therealdeal.com/fonts/ProximaNova/ProximaNova-Regular.ttf")
+      format("truetype");
+  font-weight: normal;
+  font-style: normal;
+  font-display: swap;
+}
+:root {
+  --bs-font-sans-serif: "Proxima Nova", system-ui, -apple-system, "Segoe UI",
+    Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif;
+  --bs-link-color-rgb: 0, 0, 0;
+}
+body {
+  font-family: var(--bs-font-sans-serif);
+  font-size: 14px;
+  line-height: 1.5;
+}
+main {
+  padding: 8px;
+  margin-top: 56px;
+}
+.header-style {
+  --bs-table-bg: #2196f3;
+  --bs-table-color: #fff;
+  font-weight: 600;
+  font-style: normal;
+  border-bottom: 2px solid #000;
+  font-size: 16px;
+}
+.header-style .sorted {
+  --bs-table-bg: #0d47a1;
+  font-weight: bold;
+}
+@media (prefers-color-scheme: dark) {
+  .header-style {
+    --bs-table-bg: #1976d2;
+    --bs-table-color: #fff;
+  }
+  .header-style .sorted {
+    --bs-table-bg: #0d47a1;
+  }
+}
+.header-style .sortable.both {
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" class="bi bi-arrow-down-up" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M11.5 15a.5.5 0 0 0 .5-.5V2.707l3.146 3.147a.5.5 0 0 0 .708-.708l-4-4a.5.5 0 0 0-.708 0l-4 4a.5.5 0 1 0 .708.708L11 2.707V14.5a.5.5 0 0 0 .5.5m-7-14a.5.5 0 0 1 .5.5v11.793l3.146-3.147a.5.5 0 0 1 .708.708l-4 4a.5.5 0 0 1-.708 0l-4-4a.5.5 0 0 1 .708-.708L4 13.293V1.5a.5.5 0 0 1 .5-.5"/></svg>') !important;
+}
+.header-style .sortable.desc {
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" class="bi bi-arrow-down" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 1a.5.5 0 0 1 .5.5v11.793l3.146-3.147a.5.5 0 0 1 .708.708l-4 4a.5.5 0 0 1-.708 0l-4-4a.5.5 0 0 1 .708-.708L7.5 13.293V1.5A.5.5 0 0 1 8 1"/></svg>') !important;
+}
+.header-style .sortable.asc {
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" class="bi bi-arrow-up" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 15a.5.5 0 0 0 .5-.5V2.707l3.146 3.147a.5.5 0 0 0 .708-.708l-4-4a.5.5 0 0 0-.708 0l-4 4a.5.5 0 1 0 .708.708L7.5 2.707V14.5a.5.5 0 0 0 .5.5"/></svg>') !important;
+}
+.fixed-table-toolbar {
+  position: fixed;
+  top: 0;
+  width: calc(100% - 16px);
+  z-index: 1;
+  background-color: var(--bs-body-bg);
+}
+
+.detail-icon {
+  font-size: 24px;
+  color: var(--bs-text-color);
+}

--- a/south-florida/south-florida-transactions-table.html
+++ b/south-florida/south-florida-transactions-table.html
@@ -66,14 +66,20 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
     />
-    <!-- <link
+    <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
-    /> -->
+    />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bootstrap-table@1.23.1/dist/bootstrap-table.min.css"
     />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap-table@1.23.2/dist/extensions/sticky-header/bootstrap-table-sticky-header.css"
+    />
+    <link rel="stylesheet" href="south-florida-transactions-table.css" />
+
     <!-- Google Tag Manager -->
     <script>
       (function (w, d, s, l, i) {
@@ -88,91 +94,6 @@
       })(window, document, "script", "dataLayer", "GTM-K694XL6");
     </script>
     <!-- End Google Tag Manager -->
-
-    <style>
-      @font-face {
-        font-family: "Proxima Nova";
-        src: url("https://static.therealdeal.com/fonts/ProximaNova/ProximaNova-Extrabld.woff2")
-            format("woff2"),
-          url("https://static.therealdeal.com/fonts/ProximaNova/ProximaNova-Extrabld.woff")
-            format("woff"),
-          url("https://static.therealdeal.com/fonts/ProximaNova/ProximaNova-Extrabld.ttf")
-            format("truetype");
-        font-weight: 700;
-        font-style: normal;
-        font-display: swap;
-      }
-
-      @font-face {
-        font-family: "Proxima Nova";
-        src: url("https://static.therealdeal.com/fonts/ProximaNova/ProximaNova-Semibold.woff2")
-            format("woff2"),
-          url("https://static.therealdeal.com/fonts/ProximaNova/ProximaNova-Semibold.woff")
-            format("woff"),
-          url("https://static.therealdeal.com/fonts/ProximaNova/ProximaNova-Semibold.ttf")
-            format("truetype");
-        font-weight: 600;
-        font-style: normal;
-        font-display: swap;
-      }
-
-      @font-face {
-        font-family: "Proxima Nova";
-        src: url("https://static.therealdeal.com/fonts/ProximaNova/ProximaNova-Regular.woff2")
-            format("woff2"),
-          url("https://static.therealdeal.com/fonts/ProximaNova/ProximaNova-Regular.woff")
-            format("woff"),
-          url("https://static.therealdeal.com/fonts/ProximaNova/ProximaNova-Regular.ttf")
-            format("truetype");
-        font-weight: normal;
-        font-style: normal;
-        font-display: swap;
-      }
-      :root {
-        --bs-font-sans-serif: "Proxima Nova", system-ui, -apple-system,
-          "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans",
-          Arial, sans-serif;
-        --bs-link-color-rgb: 0, 0, 0;
-      }
-      body {
-        font-family: var(--bs-font-sans-serif);
-        font-size: 14px;
-        line-height: 1.5;
-      }
-      main {
-        padding: 16px;
-      }
-      .header-style {
-        --bs-table-bg: #2196f3;
-        --bs-table-color: #fff;
-        font-weight: 600;
-        font-style: normal;
-        border-bottom: 2px solid #000;
-        font-size: 16px;
-      }
-      .header-style .sorted {
-        --bs-table-bg: #0d47a1;
-        font-weight: bold;
-      }
-      @media (prefers-color-scheme: dark) {
-        .header-style {
-          --bs-table-bg: #1976d2;
-          --bs-table-color: #fff;
-        }
-        .header-style .sorted {
-          --bs-table-bg: #0d47a1;
-        }
-      }
-      .header-style .sortable.both {
-        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" class="bi bi-arrow-down-up" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M11.5 15a.5.5 0 0 0 .5-.5V2.707l3.146 3.147a.5.5 0 0 0 .708-.708l-4-4a.5.5 0 0 0-.708 0l-4 4a.5.5 0 1 0 .708.708L11 2.707V14.5a.5.5 0 0 0 .5.5m-7-14a.5.5 0 0 1 .5.5v11.793l3.146-3.147a.5.5 0 0 1 .708.708l-4 4a.5.5 0 0 1-.708 0l-4-4a.5.5 0 0 1 .708-.708L4 13.293V1.5a.5.5 0 0 1 .5-.5"/></svg>') !important;
-      }
-      .header-style .sortable.desc {
-        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" class="bi bi-arrow-down" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 1a.5.5 0 0 1 .5.5v11.793l3.146-3.147a.5.5 0 0 1 .708.708l-4 4a.5.5 0 0 1-.708 0l-4-4a.5.5 0 0 1 .708-.708L7.5 13.293V1.5A.5.5 0 0 1 8 1"/></svg>') !important;
-      }
-      .header-style .sortable.asc {
-        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" class="bi bi-arrow-up" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 15a.5.5 0 0 0 .5-.5V2.707l3.146 3.147a.5.5 0 0 0 .708-.708l-4-4a.5.5 0 0 0-.708 0l-4 4a.5.5 0 1 0 .708.708L7.5 2.707V14.5a.5.5 0 0 0 .5.5"/></svg>') !important;
-      }
-    </style>
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->
@@ -193,167 +114,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery/dist/jquery.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap-table@1.23.1/dist/bootstrap-table.min.js"></script>
-
-    <script>
-      (function () {
-        const dataUrl =
-          "https://static.therealdeal.com/interactive-maps/map_data.geojson";
-
-        const table = document.querySelector("#luxury-sales-table");
-
-        const displayColumns = [
-          { name: "Seller" },
-          { name: "Buyer" },
-          { name: "Doc Type" },
-          {
-            name: "Record Date",
-            sorterCallback: (a, b) => {
-              if (a === "Data Not Found" || b === "Data Not Found") {
-                return 0;
-              }
-              return new Date(a).getTime() - new Date(b).getTime();
-            },
-          },
-          { name: "Sale Price" },
-          { name: "Physical Address" },
-          { name: "Folio" },
-          { name: "Use Code Description" },
-          { name: "Sq. Ft" },
-        ];
-
-        const excludeValue = [
-          "null",
-          "undefined",
-          "n/a",
-          "na",
-          "none",
-          "not available",
-          "not applicable",
-          "no",
-          "0",
-          "false",
-          "unknown",
-          "data not found",
-          "nan",
-          "-",
-        ];
-
-        const tableConfig = {
-          sortable: true,
-          search: true,
-          sortName: "record_date",
-          sortEmptyLast: true,
-          sortOrder: "desc",
-          classes: "table",
-          theadClasses: "header-style",
-          onSort: (name, order) => {
-            document
-              .querySelectorAll(".header-style .sorted")
-              .forEach((header) => {
-                header.classList.remove("sorted");
-              });
-            const header = document.querySelector(`[data-field="${name}"]`);
-            header.classList.add("sorted");
-          },
-          onPostHeader: () => {
-            document
-              .querySelectorAll(
-                ".header-style .sortable.desc, .header-style .sortable.asc"
-              )
-              .forEach((header) => {
-                header.parentNode.classList.add("sorted");
-              });
-          },
-        };
-
-        if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-          document.body.setAttribute("data-bs-theme", "dark");
-        }
-
-        const isEmptyValue = (value) => {
-          if (!value) return true;
-          if (value === "") return true;
-          if (typeof value === "string") {
-            if (value.trim() === "") return true;
-            if (excludeValue.includes(value.toLowerCase())) return true;
-          }
-          return false;
-        };
-
-        const formatter = (value, row, index, field) => {
-          if (isEmptyValue(value)) {
-            return '<span class="text-muted">N/A</span>';
-          }
-
-          if (field === "sale_price") {
-            return new Intl.NumberFormat("en-US", {
-              style: "currency",
-              currency: "USD",
-              minimumFractionDigits: 0, // No decimal places
-              maximumFractionDigits: 0, // No decimal places
-            }).format(value);
-          }
-
-          if (field === "record_date") {
-            return new Date(value).toLocaleDateString();
-          }
-
-          return value;
-        };
-
-        const columnConfig = {
-          sortable: true,
-          formatter: formatter,
-        };
-
-        const getData = async (url) => {
-          const response = await fetch(url);
-          return response.json();
-        };
-
-        const mapDataToTable = (data) => {
-          const columns = displayColumns.map((column) => ({
-            ...columnConfig,
-            field: column.name
-              .toLowerCase()
-              .replace(/ /g, "_")
-              .replace(/\./g, ""),
-            title: column.name,
-            sorter: column.sorterCallback ? column.sorterCallback : undefined,
-          }));
-
-          const rows = data.features.map((feature) => {
-            const properties = feature.properties;
-            const row = {};
-
-            columns.forEach((column) => {
-              row[column.field] = properties[column.title];
-            });
-
-            return row;
-          });
-
-          return {
-            columns,
-            rows,
-          };
-        };
-
-        const renderTable = (data) => {
-          $(table).bootstrapTable({
-            ...tableConfig,
-            columns: data.columns,
-            data: data.rows,
-          });
-        };
-
-        getData(dataUrl)
-          .then(mapDataToTable)
-          .then(renderTable)
-          .catch((error) => {
-            console.error(error);
-          });
-      })();
-    </script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap-table@1.23.2/dist/extensions/sticky-header/bootstrap-table-sticky-header.min.js"></script>
+    <script src="south-florida-transactions-table.js"></script>
   </body>
 </html>

--- a/south-florida/south-florida-transactions-table.js
+++ b/south-florida/south-florida-transactions-table.js
@@ -26,7 +26,6 @@
 
   const displayFields = [
     "Doc Type",
-    "Instrument_Num",
     "Record Date",
     "Seller",
     "Buyer",
@@ -56,8 +55,6 @@
     "Second Party State",
     "Second Party Date Filed",
     "Full Address",
-    "UniqueID",
-    "TransactionID",
     "Lender",
     "Loan Amount",
   ];
@@ -77,6 +74,8 @@
     "data not found",
     "nan",
     "-",
+    "folio not found!",
+    "folio not found",
   ];
 
   const trackEvent = (action, label) => {
@@ -209,13 +208,27 @@
       }).format(value);
     }
 
-    if (field === "sale_price" || field === "loan_amount") {
-      return new Intl.NumberFormat("en-US", {
-        style: "currency",
-        currency: "USD",
-        minimumFractionDigits: 0, // No decimal places
-        maximumFractionDigits: 0, // No decimal places
-      }).format(value);
+    if (
+      field === "sale_price" ||
+      field === "loan_amount" ||
+      field === "previous_sale_price"
+    ) {
+      try {
+        const number =
+          typeof value === "string"
+            ? parseFloat(value.replace(/[$,]/g, ""))
+            : value;
+
+        console.log(field, value, number);
+        return new Intl.NumberFormat("en-US", {
+          style: "currency",
+          currency: "USD",
+          minimumFractionDigits: 0, // No decimal places
+          maximumFractionDigits: 0, // No decimal places
+        }).format(number);
+      } catch (e) {
+        return value;
+      }
     }
 
     if (field === "record_date") {

--- a/south-florida/south-florida-transactions-table.js
+++ b/south-florida/south-florida-transactions-table.js
@@ -219,7 +219,6 @@
             ? parseFloat(value.replace(/[$,]/g, ""))
             : value;
 
-        console.log(field, value, number);
         return new Intl.NumberFormat("en-US", {
           style: "currency",
           currency: "USD",

--- a/south-florida/south-florida-transactions-table.js
+++ b/south-florida/south-florida-transactions-table.js
@@ -1,0 +1,312 @@
+(function () {
+  const dataUrl =
+    "https://static.therealdeal.com/interactive-maps/map_data.geojson";
+
+  const table = document.querySelector("#luxury-sales-table");
+
+  const displayColumns = [
+    { dataField: "Seller", name: "Seller" },
+    { dataField: "Buyer", name: "Buyer" },
+    {
+      dataField: "Record Date",
+      name: "Record Date",
+      sorterCallback: (a, b) => {
+        if (a === "Data Not Found" || b === "Data Not Found") {
+          return 0;
+        }
+        return new Date(a).getTime() - new Date(b).getTime();
+      },
+    },
+    { dataField: "Sale Price", name: "Sale Price" },
+    { dataField: "Physical Address", name: "Physical Address" },
+    { dataField: "Folio", name: "Folio" },
+    { dataField: "Use Code Description", name: "Use Code Description" },
+    { dataField: "Building Sq. Ft", name: "Sq. Ft" },
+  ];
+
+  const displayFields = [
+    "Doc Type",
+    "Instrument_Num",
+    "Record Date",
+    "Seller",
+    "Buyer",
+    "Sale Price",
+    "Folio",
+    "Use Code Description",
+    "Building Sq. Ft",
+    "Lot Size",
+    "Date of Previous Sale",
+    "Previous Owner Name",
+    "Previous Sale Price",
+    "Physical Address",
+    "Mailing Address",
+    "First Party Registered Agent Name & Address",
+    "First Party Document Number",
+    "First Party FEI/EIN Number",
+    "First Party Mailing Address",
+    "First Party Principal Address",
+    "First Party State",
+    "First Party Date Filed",
+    "Second Party Registered Agent Name & Address",
+    "Second Party Status",
+    "Second Party Document Number",
+    "Second Party FEI/EIN Number",
+    "Second Party Mailing Address",
+    "Second Party Principal Address",
+    "Second Party State",
+    "Second Party Date Filed",
+    "Full Address",
+    "UniqueID",
+    "TransactionID",
+    "Lender",
+    "Loan Amount",
+  ];
+
+  const excludeValue = [
+    "null",
+    "undefined",
+    "n/a",
+    "na",
+    "none",
+    "not available",
+    "not applicable",
+    "no",
+    "0",
+    "false",
+    "unknown",
+    "data not found",
+    "nan",
+    "-",
+  ];
+
+  const trackEvent = (action, label) => {
+    if (window.dataLayer) {
+      window.dataLayer.push({
+        event: "event_tracking",
+        trd: {
+          category: "south-florida-transactions-table",
+          action: `table_${action}`,
+          label: label,
+        },
+      });
+    }
+  };
+
+  const mapDetailRow = (key, row, i) => {
+    const value = row[key];
+    if (isEmptyValue(value)) {
+      return "";
+    }
+    return `<tr>
+      <td class="text-capitalize">
+      ${key.replace(/_/g, " ")}
+      </td>
+      <td>${formatter(value, row, i, key)}</td>
+    </tr>`;
+  };
+
+  const detailFormatter = (index, row) => {
+    const displayRows = displayFields.filter(
+      (field) => !isEmptyValue(row[getFieldName(field)])
+    );
+
+    trackEvent(
+      "detail_open",
+      row.physical_address ? row.physical_address : "Unknown Address"
+    );
+
+    return `
+      <div class="container">
+        <div class="row my-5">
+          <div class="col-12 col-md-6">
+            <table class="table table-sm">
+              <tbody>
+                ${displayRows
+                  .slice(0, Math.ceil(displayRows.length / 2))
+                  .map((key, i) => mapDetailRow(getFieldName(key), row, i))
+                  .join("")}
+              </tbody>
+            </table>
+          </div>
+          <div class="col-12 col-md-6">
+            <table class="table table-sm">
+              <tbody>
+                ${displayRows
+                  .slice(Math.ceil(displayRows.length / 2))
+                  .map((key, i) => mapDetailRow(getFieldName(key), row, i))
+                  .join("")}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    `;
+  };
+
+  const tableConfig = {
+    sortable: true,
+    search: true,
+    searchHighlight: true,
+    sortName: "record_date",
+    sortEmptyLast: true,
+    sortOrder: "desc",
+    sortEmptylast: true,
+    classes: "table table-responsive",
+    theadClasses: "header-style",
+    detailView: true,
+    detailFormatter: detailFormatter,
+    icons: {
+      detailOpen: "bi bi-chevron-down",
+      detailClose: "bi bi-chevron-up",
+    },
+    showColumns: true,
+    showColumnsToggleAll: true,
+    minimumCountColumns: 2,
+    stickyHeader: true,
+    stickyHeaderOffsetY: 56,
+    stickyHeaderOffsetLeft: parseInt($("body").css("padding-left"), 10),
+    stickyHeaderOffsetRight: parseInt($("body").css("padding-right"), 10),
+    onSort: (name, order) => {
+      document.querySelectorAll(".header-style .sorted").forEach((header) => {
+        header.classList.remove("sorted");
+      });
+      const header = document.querySelector(`[data-field="${name}"]`);
+      header.classList.add("sorted");
+    },
+    onPostHeader: () => {
+      document
+        .querySelectorAll(
+          ".header-style .sortable.desc, .header-style .sortable.asc"
+        )
+        .forEach((header) => {
+          header.parentNode.classList.add("sorted");
+        });
+    },
+  };
+
+  if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    document.body.setAttribute("data-bs-theme", "dark");
+  }
+
+  const isEmptyValue = (value) => {
+    if (!value) return true;
+    if (value === "") return true;
+    if (typeof value === "string") {
+      if (value.trim() === "") return true;
+      if (excludeValue.includes(value.toLowerCase())) return true;
+    }
+    return false;
+  };
+
+  const formatter = (value, row, index, field) => {
+    if (isEmptyValue(value)) {
+      return '<span class="text-muted">N/A</span>';
+    }
+
+    if (field === "building_sq_ft") {
+      return new Intl.NumberFormat("en-US", {
+        style: "decimal",
+      }).format(value);
+    }
+
+    if (field === "sale_price" || field === "loan_amount") {
+      return new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        minimumFractionDigits: 0, // No decimal places
+        maximumFractionDigits: 0, // No decimal places
+      }).format(value);
+    }
+
+    if (field === "record_date") {
+      return new Date(value).toLocaleDateString();
+    }
+
+    return value;
+  };
+
+  const getFieldName = (value) => {
+    return value.toLowerCase().replace(/ /g, "_").replace(/\./g, "");
+  };
+
+  const columnConfig = {
+    sortable: true,
+    formatter: formatter,
+  };
+
+  const getData = async (url) => {
+    const response = await fetch(url);
+    return response.json();
+  };
+
+  const mapDataToTable = (data) => {
+    const columns = Object.keys(data.features[0].properties)
+      .sort((a, b) => {
+        // sort it by displayColumns order
+        const aIndex = displayColumns.findIndex(
+          (column) => column.dataField === a
+        );
+        const bIndex = displayColumns.findIndex(
+          (column) => column.dataField === b
+        );
+        if (aIndex === -1 && bIndex !== -1) return 1;
+        if (aIndex !== -1 && bIndex === -1) return -1;
+        if (aIndex === -1 && bIndex === -1) return 0;
+
+        return aIndex - bIndex;
+      })
+      .map((property) => {
+        if (!displayFields.includes(property)) {
+          return null;
+        }
+        const displayColumn = displayColumns.find(
+          (column) => column.dataField === property
+        );
+
+        const sorter =
+          displayColumn && typeof displayColumn.sorterCallback === "function"
+            ? displayColumn.sorterCallback
+            : undefined;
+
+        return {
+          ...columnConfig,
+          field: getFieldName(property),
+          title: (displayColumn && displayColumn.name) || property,
+          sorter,
+          visible: displayColumn ? true : false,
+        };
+      })
+      .filter((column) => column);
+
+    const rows = data.features.map((feature) => {
+      const properties = feature.properties;
+      const row = {};
+
+      displayFields.forEach((field) => {
+        row[getFieldName(field)] = properties[field];
+      });
+
+      return row;
+    });
+
+    return {
+      columns,
+      rows,
+    };
+  };
+
+  const renderTable = (data) => {
+    $(table).bootstrapTable({
+      ...tableConfig,
+      columns: data.columns,
+      data: data.rows,
+    });
+  };
+
+  getData(dataUrl)
+    .then(mapDataToTable)
+    .then(renderTable)
+    .catch((error) => {
+      console.error(error);
+    });
+})();

--- a/south-florida/south-florida-transactions-table.js
+++ b/south-florida/south-florida-transactions-table.js
@@ -11,7 +11,7 @@
       dataField: "Record Date",
       name: "Record Date",
       sorterCallback: (a, b) => {
-        if (a === "Data Not Found" || b === "Data Not Found") {
+        if (isEmptyValue(a) || isEmptyValue(b)) {
           return 0;
         }
         return new Date(a).getTime() - new Date(b).getTime();


### PR DESCRIPTION
This PR updates the South Florida table:
- add a stick header
- allow users to select different columns to display
- add a detail view to show hidden columns
- fix the Sq. Ft display value
- Move the js and CSS into it's own file

![Screenshot 2024-08-01 at 3 12 42 PM](https://github.com/user-attachments/assets/4c598e1b-519a-4094-8c79-58c7e91c27b3)
