### PR TITLE
TRD-3594: Was fixed scroll bug after Filter button click and headline text

### DIFF
--- a/commercial-office-market/js/main.js
+++ b/commercial-office-market/js/main.js
@@ -142,7 +142,7 @@ const сommercialOfficeMarket = () => {
 		autoscroll: (event) => {
 			setTimeout(() => {
 				const input = event.target.parentElement.querySelector("input:checked");
-				if (input) input.scrollIntoView(true);
+				if (input) input.scrollIntoView({ behavior: "instant", block: "nearest", inline: "start", });
 			}, 20);
 		},
 
@@ -279,7 +279,7 @@ const сommercialOfficeMarket = () => {
 		renderResults: () => {
 			// Show headline.
 			if (results.headline) {
-				const quarter = (connector.accessKeys.vacancyRate ? ` ${connector.accessKeys.vacancyRate}` : "");
+				const quarter = (connector.accessKeys.vacancyRate ? ` ${helpers.formatQuarter(connector.accessKeys.vacancyRate)}` : "");
 				headline.innerHTML = `${helpers.formatString(results.headline)} Office Market${quarter}`;
 			} else {
 				headline.innerHTML = `Office Market`;
@@ -353,6 +353,16 @@ const сommercialOfficeMarket = () => {
 	};
 
 	const helpers = {
+		formatQuarter: (value) => {
+			let result = "";
+
+			if (helpers.isString(value)) {
+				result = value.replace("p", "");
+			}
+
+			return result;
+		},
+
 		formatString: (value) => {
 			let result = "";
 


### PR DESCRIPTION
Were added two fixes for Commercial Office Market National Data widget.

How to test the new fixes:
1. Click on the Filter button the List Dropdown should be shown and browser scroll does not to do any jumps. This is OK. If we have any browser scroll (jump) after clicking the button, then the fix does not work.

2. The headline text that placed undet the Logo should comtain the year without the "p" char. For example:
Miami, FL Office Market Q2 2024 (CORRECT)
Miami, FL Office Market Q2 2024p (WRONG)

Thanks!
![Screenshot](https://github.com/user-attachments/assets/20178268-6f0d-43b8-8992-d8f2cebddf40)
