### PR TITLE
Feature/TRD-3617: Were updated the Title and Info. Small CSS fixes.

### DIFF
--- a/new-york/new-york-city-transactions-list.css
+++ b/new-york/new-york-city-transactions-list.css
@@ -145,15 +145,14 @@ ul li {	pointer-events: none; }*/
 	overflow-y: auto;
 	cursor: pointer;
 }
-.card .luxury-sales-list li {
-	min-height: 60px;
-}
 .card .luxury-sales-list li .price {
+	text-align: right;
 	font-family: "Merriweather", serif;
 	font-weight: 700;
 	font-size: 1rem;
 }
 .card .luxury-sales-list li .date {
+	text-align: right;
 	font-size: 0.75rem;
 }
 @media (prefers-color-scheme: dark) {

--- a/new-york/new-york-city-transactions-list.html
+++ b/new-york/new-york-city-transactions-list.html
@@ -13,18 +13,18 @@
 		/>
 
 		<!-- Primary meta tags. -->
-		<title>Top 10 NYC ACRIS Sales - The Real Deal</title>
+		<title>Priciest NYC Sales In Last Month - The Real Deal</title>
 		<meta
 			name="title"
-			content="Top 10 NYC ACRIS Sales - The Real Deal"
+			content="Priciest NYC Sales In Last Month - The Real Deal"
 		/>
 		<meta
 			name="description"
-			content="Top 10 NYC ACRIS Sales."
+			content="This dataset shows the top 10 priciest residential transactions in NYC over the past 30 days."
 		/>
 		<link
 			rel="canonical"
-			href="https://therealdeal.com/data/miami/2024/priciest-new-york-city-sales/"
+			href="https://therealdeal.com/data/"
 		/>
 
 		<!-- Open Graph/Facebook meta tags. -->
@@ -34,15 +34,15 @@
 		/>
 		<meta
 			property="og:url"
-			content="https://therealdeal.com/data/miami/2024/priciest-new-york-city-sales/"
+			content="https://therealdeal.com/data/"
 		/>
 		<meta
 			property="og:title"
-			content="NYC ACRIS - The Real Deal"
+			content="Priciest NYC Sales In Last Month - The Real Deal"
 		/>
 		<meta
 			property="og:description"
-			content="Latest NYC ACRIS"
+			content="This dataset shows the top 10 priciest residential transactions in NYC over the past 30 days."
 		/>
 		<meta
 			property="og:image"
@@ -56,15 +56,15 @@
 		/>
 		<meta
 			property="twitter:url"
-			content="https://therealdeal.com/data/miami/2024/priciest-new-york-city-sales/"
+			content="https://therealdeal.com/data/"
 		/>
 		<meta
 			property="twitter:title"
-			content="NYC ACRIS - The Real Deal"
+			content="Priciest NYC Sales In Last Month - The Real Deal"
 		/>
 		<meta
 			property="twitter:description"
-			content="Latest NYC ACRIS"
+			content="This dataset shows the top 10 priciest residential transactions in NYC over the past 30 days."
 		/>
 		<meta
 			property="twitter:image"
@@ -179,7 +179,7 @@
 								class="button-icon button-icon-info"
 								data-bs-toggle="tooltip"
 								data-bs-placement="bottom"
-								data-bs-title="Info"
+								data-bs-title="This dataset shows the top 10 priciest residential transactions in NYC over the past 30 days."
 							>
 								<i class="bi bi-info-circle"></i>
 							</span>
@@ -192,7 +192,7 @@
 							class="text-capitalize"
 							href="https://therealdeal.com/data/"
 							target="_blank"
-						>Priciest Sales in NYC</a
+						>Priciest NYC Sales In Last Month</a
 						>
 					</h1>
 				</div>


### PR DESCRIPTION
Was added the new title at the Top Left:
"Priciest NYC Sales In Last Month"

Was added the new info at the Top Right:
"This dataset shows the top 10 priciest residential transactions in NYC over the past 30 days."

Please review the result on the screenshot:
![TRD-3617-Light-Theme-New-Title-New-Info](https://github.com/user-attachments/assets/61cd6848-b992-4899-a51e-41f93bfec318)


Thanks!
