### PR TITLE
[TRD-4274] Create Miami construction map HTML

### DIFF
--- a/MiamiCity_Permits/filter-extension.js
+++ b/MiamiCity_Permits/filter-extension.js
@@ -1,0 +1,78 @@
+// Add event listeners to the filter form after it's been created
+document.addEventListener('DOMContentLoaded', () => {
+    // Wait for the filter form to be created
+    const checkFilterForm = () => {
+        const filterForm = document.getElementById('map-filters');
+        if (filterForm) {
+            console.log('Filter form found, adding event listeners');
+
+            // Add event listeners to the filter form buttons
+            const applyBtn = filterForm.querySelector('button[type="submit"]');
+            const resetBtn = filterForm.querySelector('button[type="reset"]');
+
+            if (applyBtn) {
+                applyBtn.addEventListener('click', () => {
+                    console.log('Apply filter button clicked');
+                    // Schedule refresh after the map updates
+                    setTimeout(() => {
+                        if (window.refreshStatusCounts) {
+                            console.log('Refreshing status counts after apply');
+                            window.refreshStatusCounts();
+                        }
+                    }, 500);
+                });
+            }
+
+            if (resetBtn) {
+                resetBtn.addEventListener('click', () => {
+                    console.log('Reset filter button clicked');
+                    // Schedule refresh after the map updates
+                    setTimeout(() => {
+                        if (window.refreshStatusCounts) {
+                            console.log('Refreshing status counts after reset');
+                            window.refreshStatusCounts();
+                        }
+                    }, 500);
+                });
+            }
+
+            return true;
+        }
+        return false;
+    };
+
+    // Check immediately, then start checking periodically if not found
+    if (!checkFilterForm()) {
+        const checkInterval = setInterval(() => {
+            if (checkFilterForm()) {
+                clearInterval(checkInterval);
+            }
+        }, 500);
+
+        // Clear interval after 10 seconds if filter form never appears
+        setTimeout(() => clearInterval(checkInterval), 10000);
+    }
+
+    // Check for the map object to add a load event listener
+    const mapCheckInterval = setInterval(() => {
+        if (window.map) {
+            console.log('Map object found, adding load event listener');
+            window.map.on('load', () => {
+                console.log('Map loaded, dispatching mapboxglLoaded event');
+                document.dispatchEvent(new CustomEvent('mapboxglLoaded'));
+
+                // Also refresh status counts directly after map load
+                setTimeout(() => {
+                    if (window.refreshStatusCounts) {
+                        console.log('Directly refreshing status counts after map load');
+                        window.refreshStatusCounts();
+                    }
+                }, 1500);
+            });
+            clearInterval(mapCheckInterval);
+        }
+    }, 300);
+
+    // Clear interval after 10 seconds if map never appears
+    setTimeout(() => clearInterval(mapCheckInterval), 10000);
+});

--- a/MiamiCity_Permits/miami-construction-map.html
+++ b/MiamiCity_Permits/miami-construction-map.html
@@ -29,6 +29,45 @@
             margin: 0;
             line-height: 1.25rem;
         }
+
+        /* Year range slider styling */
+        .range-slider {
+            position: relative;
+            height: 8px;
+            background-color: #e9ecef;
+            border-radius: 4px;
+            margin: 20px 0;
+        }
+
+        .range-slider-progress {
+            position: absolute;
+            height: 100%;
+            background-color: #007bff;
+            border-radius: 4px;
+        }
+
+        .range-slider-min,
+        .range-slider-max {
+            position: absolute;
+            width: 20px;
+            height: 20px;
+            background-color: white;
+            border: 2px solid #007bff;
+            border-radius: 50%;
+            top: -6px;
+            cursor: pointer;
+            z-index: 1;
+        }
+
+        .range-slider-label {
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 5px;
+        }
+
+        .year-slider-container {
+            padding: 10px 5px;
+        }
     </style>
 
     <!-- Google Tag Manager -->
@@ -60,6 +99,7 @@
     <script src="../trd-data/common-formatter/formatter.js"></script>
     <script src="../trd-data/common-loading/loading.js"></script>
     <script src="../trd-data/common-map/map.js?v=1.1"></script>
+    <script src="filter-extension.js"></script>
     <script>
         // 1 Active -> 2 Hold -> 3 Final -> 4 Expired -> 5 Revoked -> 6 Other
         // Colors chosen for distinct hue / role; neutral gray for inactive, red for invalid.
@@ -153,8 +193,6 @@
                     field: "CompanyNamesAsHTML",
                     label: "Involved Companies",
                 },
-                { field: "Latitude", label: "Latitude" },
-                { field: "Longitude", label: "Longitude" },
                 {
                     field: "Link_Check",
                     label: "Property Reference Link",
@@ -194,6 +232,25 @@
                     { label: "Revoked", value: "Revoked" }
                 ],
             },
+            {
+                title: "Latest Permit Year",
+                name: "year",
+                dataField: "LatestPermitYear",
+                fieldType: "multi-range",
+                fieldLayoutClass: "year-slider-container",
+                minValue: 2010, // Starting year
+                maxValue: 2025, // Current year 
+                allowZero: false,
+                defaultValue: [2010, 2025], // Full range by default
+                format: "formatInteger",
+                callback: (values, item) => {
+                    if (!values || values.length !== 2) return true;
+                    const year = parseInt(item.properties?.LatestPermitYear, 10);
+                    if (!year || isNaN(year)) return false; // Skip if no valid year
+                    const [minYear, maxYear] = values.map(v => parseInt(v, 10));
+                    return year >= minYear && year <= maxYear;
+                }
+            }
         ];
 
         const list = [];
@@ -233,6 +290,7 @@
                     continue; // skip unmapped status
                 }
 
+
                 // include feature
                 if (status && !list.includes(status)) {
                     list.push(status);
@@ -250,6 +308,15 @@
                 });
             }
 
+            // Schedule an update for the filter labels after a short delay
+            // This gives time for the DOM to be ready for the count display
+            setTimeout(() => {
+                if (typeof window.refreshStatusCounts === 'function') {
+                    console.log("Calling refreshStatusCounts from fetchDataFilterCallback");
+                    window.refreshStatusCounts();
+                }
+            }, 1500);
+
             return {
                 ...data,
                 features: filteredFeatures,
@@ -257,6 +324,17 @@
         };
 
         window.list = list;
+
+        // Listen for mapbox load event to trigger status count update
+        document.addEventListener('mapboxglLoaded', function () {
+            console.log("Map loaded event received");
+            setTimeout(() => {
+                if (window.refreshStatusCounts) {
+                    console.log("Refreshing status counts after map load");
+                    window.refreshStatusCounts();
+                }
+            }, 1000);
+        });
 
         window.map = trdDataCommonMap({
             fetchDataFilterCallback,
@@ -285,7 +363,10 @@
                 paintSettings: {
                     default: { radius: 6 },
                     hover: { color: { light: "#FF9800", dark: "#F57C00" } },
-                    active: { color: { light: "#FF5722", dark: "#D84315" } },
+                    active: {
+                        radius: 15,
+                        color: { light: "#FF5722", dark: "#D84315" }
+                    },
                 },
             },
         });
@@ -294,19 +375,34 @@
         (function statusFilterCounts() {
             function updateLabels() {
                 const form = document.getElementById('map-filters');
-                if (!form) return;
+                if (!form) {
+                    console.log("Filter form not found");
+                    return;
+                }
+
+
                 const optionContainers = form.querySelectorAll('.filter-option-container');
-                if (!optionContainers.length) return;
+                if (!optionContainers.length) {
+                    console.log("No filter option containers found");
+                    return;
+                }
 
                 // Build a set of known option ids for the status field
                 optionContainers.forEach(container => {
                     const input = container.querySelector('input[name="status"]');
                     const label = container.querySelector('label.filter-option');
-                    if (!input || !label) return;
+
+                    if (!input || !label) {
+                        console.log("Missing input or label in container", container);
+                        return;
+                    }
+
                     // store base label once
                     if (!label.dataset.baseLabel) {
                         label.dataset.baseLabel = label.textContent.replace(/\s*\(.*\)$/, '').trim();
+                        console.log(`Set base label for ${input.value}: "${label.dataset.baseLabel}"`);
                     }
+
                     const value = input.value; // '' for Other
                     const count = window.statusCounts ? (window.statusCounts[value] || 0) : 0;
                     label.textContent = `${label.dataset.baseLabel} (${count.toLocaleString()})`;
@@ -317,21 +413,55 @@
             let attempts = 0;
             const interval = setInterval(() => {
                 attempts++;
+
+                // Check if DOM and data are ready
+                const formReady = document.getElementById('map-filters') !== null;
+                const dataReady = Object.keys(window.statusCounts || {}).length > 0;
+
+                // Always try to update - we want to keep trying even if initially unsuccessful
                 updateLabels();
-                // stop if we have counts applied and counts object has keys
-                if (Object.keys(window.statusCounts || {}).length && document.querySelector('#map-filters label[data-base-label]')) {
+
+                // Only stop interval if both form and data are ready and labels were updated
+                if (dataReady && formReady && document.querySelector('#map-filters label[data-base-label]')) {
                     clearInterval(interval);
                 }
-                if (attempts > 40) { // ~20s fallback
+
+                if (attempts > 60) { // ~30s fallback - increased from 20s
                     clearInterval(interval);
                 }
             }, 500);
 
-            // (Optional) public API to refresh after external filtering
-            window.refreshStatusCounts = () => updateLabels();
+            // Public API to refresh after external filtering
+            window.refreshStatusCounts = () => {
+                console.log("Manual refresh of status counts called");
+                updateLabels();
+            };
+
+            // Make the counts update after map data is loaded
+            document.addEventListener('DOMContentLoaded', () => {
+                console.log("DOM loaded - setting up additional trigger");
+
+                // Add an observer to detect when the filter form is added to the DOM
+                const observer = new MutationObserver((mutations) => {
+                    for (const mutation of mutations) {
+                        if (mutation.addedNodes.length) {
+                            const filterForm = document.getElementById('map-filters');
+                            if (filterForm) {
+                                setTimeout(updateLabels, 1000); // Give some time for counts to be ready
+                                observer.disconnect();
+                                break;
+                            }
+                        }
+                    }
+                });
+
+                // Start observing the body for when the filter form is added
+                observer.observe(document.body, { childList: true, subtree: true });
+            });
 
             // If a custom filtered event is dispatched with features, recompute counts
             document.addEventListener('trd:map:filtered', (e) => {
+                console.log("Custom filtered event received");
                 if (e.detail && Array.isArray(e.detail.features)) {
                     // recompute counts from provided feature set
                     const newCounts = {};
@@ -347,7 +477,6 @@
             });
         })();
         // --- End status count labels updater ---
-
     </script>
 </body>
 


### PR DESCRIPTION
## Overview

The branch contains a new interactive construction permits map for the City of Miami via miami-construction-map.html. The map visualizes permit activity with filtering by latest permit status and year, legend-driven styling, tooltips, and modal views. It’s intended for publication to production as a reader-facing data visualization asset under The Real Deal’s interactive map standards.

The HTML file follows the patterns already used across other geography-based map interactives in the repository while containing dynamic filter count handling and status normalization.

## Technical Details

### Data Flow
1. Remote GeoJSON fetched from:
   `https://static.therealdeal.com/interactive-maps/miami-construction-map.geojson`
2. `fetchDataFilterCallback`:
   - Filters out records with blank or unmapped `LatestStatus`.
   - Builds `statusCounts` used in filter labels.
   - Logs exclusion diagnostics (counts + samples) for QA.
3. Map instance created via `trdDataCommonMap` with injected config objects for:
   - Legend keys and point color mapping (case-based style).
   - Tooltip/modal field descriptors with formatting hooks (`formatDate`, `formatLink`).
   - Filter schema, including custom callback logic per field.

### Filter UX
- Status filter uses multi-select checkbox group with live count update.
- Year filter implemented as a dual-handle custom slider (2010–2025 inclusive).
- Counts update strategy:
  - Interval attempts until both DOM + data ready (up to ~30s fallback).
  - Listens for a custom `trd:map:filtered` event to recalc from filtered feature set.
  - Public `window.refreshStatusCounts()` enables external/manual triggers.

### Styling & Interaction
- Color palette selected for contrast and semantic grouping (e.g., Expired → gray, Revoked → red).
- Active marker enlarges radius (15px) for spatial focus.
- Hover state highlight color distinct from active.
- Map configured with conservative minZoom to avoid clutter.

### Defensive / Resilience Measures
- Null/empty feature collection guard.
- Status string normalization (`trim`, lowercase poisoning safeguard for “black”) for the filter.
- Safe property access with optional chaining.
- Avoids silent failure: there are some console logs.

### Extensibility Hooks
- `legendKeys` + `dataPointKeys` allow future status additions.
- Year slider min/max easily adjustable (e.g., 2005–current year).
- Modal / tooltip field arrays can expand without structural refactor.

## Performance Notes
- Pre-filtering reduces in-browser point churn.
- Uses small radii to minimize overdraw at low zooms.
- Defers label updates slightly to avoid layout thrash.

## Risks / Mitigations
| Risk | Mitigation |
| ---- | ---------- |
| Upstream GeoJSON schema changes (field rename) | Defensive property access + console diagnostics |
| Missing / new status values | Filter excludes & logs unmapped; easily extend `legendKeys` |
| Slider usability on mobile | Handles sized at 20px; can refine with touch events if feedback suggests |

## Follow-Up Opportunities (Optional)
- Add keyboard accessibility + ARIA for slider.
- Lazy-load GeoJSON with ETag-based caching.
- Add export (CSV / filtered subset) button.
- Provide on-map clustering toggle at lower zooms.
- Snapshot tests for legend & filter rendering.

## How to Review
1. Open miami-construction-map.html directly in a local server (ensure cross-origin font/map loads).
2. Confirm:
   - Legend matches visible marker colors.
   - Status counts decrement/increment as filters applied.
   - Year filtering works for edge values (2010 only, 2025 only).
   - Modal link field opens valid reference URL.
3. Check console for any warnings after initial load.


<img width="1725" height="991" alt="Screenshot 2025-09-19 at 12 32 18 PM" src="https://github.com/user-attachments/assets/f522899e-bfa8-48b2-95ca-2c94f4594676" />


## Deployment Notes
- No backend changes required.
- Ensure the referenced GeoJSON is already deployed and publicly accessible before merging.
- If CDN cache is used for the HTML asset path, purge/ban after release.

## Request for Feedback
All suggestions welcome—especially on:
- Color palette accessibility.
- Filter UX (should we add “Select All / None”?).
- Additional derived metrics worth showing (e.g., aggregation by property type).
- Performance with full dataset at lower zoom levels.

Please feel free to propose refinements or push follow-up commits; I’m happy to iterate.

Let me know if you'd like this broken into smaller modular JS assets before merge.